### PR TITLE
Updated versions of: Compose, room, Kotlin

### DIFF
--- a/projects/android/build.gradle.kts
+++ b/projects/android/build.gradle.kts
@@ -5,8 +5,8 @@
  * Learn more about Gradle by exploring our samples at https://docs.gradle.org/7.1/samples
  */
 plugins {
-    kotlin("jvm") version "1.5.31" apply false
-    kotlin("plugin.serialization") version "1.5.31"
+    kotlin("jvm") version "1.6.21" apply false
+    kotlin("plugin.serialization") version "1.6.21"
 }
 
 buildscript {
@@ -18,10 +18,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
-        classpath("com.android.tools.build:gradle:7.0.3")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
+        classpath("com.android.tools.build:gradle:7.2.1")
         classpath("org.javassist:javassist:3.27.0-GA")
-        classpath(kotlin("gradle-plugin", version = "1.5.31"))
+        classpath(kotlin("gradle-plugin", version = "1.6.21"))
         classpath(files("deps/ms-intune-app-sdk-android-8.0.0/GradlePlugin/com.microsoft.intune.mam.build.jar"))
     }
 }

--- a/projects/android/eyeonit/build.gradle.kts
+++ b/projects/android/eyeonit/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdk = 31
+    compileSdk = 32
 
     defaultConfig {
         applicationId = "io.eyeonit.eyeonit"
         minSdk=21
-        targetSdk=31
+        targetSdk=32
         versionCode = 1
         versionName = "1.0"
 
@@ -36,7 +36,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.0.4"
+        kotlinCompilerExtensionVersion = "1.2.0-beta03"
     }
 }
 
@@ -48,15 +48,15 @@ dependencies {
     //Kotlin Co-routines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
 
-    val compose_version = "1.0.4"
+    val compose_version = "1.2.0-beta03"
 
-    implementation("androidx.core:core-ktx:1.6.0")
+    implementation("androidx.core:core-ktx:1.8.0")
     implementation("androidx.compose.ui:ui:$compose_version")
     implementation("androidx.compose.material:material:$compose_version")
     implementation("androidx.compose.material:material-icons-extended:$compose_version")
-    implementation("androidx.activity:activity-compose:1.3.1")
+    implementation("androidx.activity:activity-compose:1.4.0")
     implementation("androidx.compose.ui:ui-tooling:$compose_version")
-    implementation("androidx.navigation:navigation-compose:2.4.0-alpha10")
+    implementation("androidx.navigation:navigation-compose:2.4.2")
 
     // UI Tests
     testImplementation("junit:junit:4.+")

--- a/projects/android/findbugs-android-exclude.xml
+++ b/projects/android/findbugs-android-exclude.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <!-- http://stackoverflow.com/questions/7568579/eclipsefindbugs-exclude-filter-files-doesnt-work -->
+    <Match>
+        <Or>
+            <Class name="~.*\.R\$.*"/>
+            <Class name="~.*\.Manifest\$.*"/>
+        </Or>
+    </Match>
+</FindBugsFilter>

--- a/projects/android/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/projects/android/secure/build.gradle.kts
+++ b/projects/android/secure/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("com.google.devtools.ksp") version "1.5.31-1.0.0"
+    id("com.google.devtools.ksp") version "1.6.21-1.0.6"
     kotlin("kapt")
 }
 
@@ -37,8 +37,8 @@ dependencies {
     /**
      * Android UI Libraries
      */
-    implementation("androidx.appcompat:appcompat:1.3.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.1")
+    implementation("androidx.appcompat:appcompat:1.4.2")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
     /**
      * MSAL
@@ -48,7 +48,7 @@ dependencies {
 
     /**
      * Start Work Manager     */
-    val workVersion = "2.6.0"
+    val workVersion = "2.7.1"
 
     // (Java only)
     implementation("androidx.work:work-runtime:$workVersion")
@@ -72,16 +72,13 @@ dependencies {
     /**
      * Start Room Dependencies
      */
-    //Kotlin Symbolic processing
-    implementation("com.google.devtools.ksp:symbol-processing-api:1.5.31-1.0.0")
-
-    val roomVersion = "2.3.0"
+    val roomVersion = "2.4.2"
 
     implementation("androidx.room:room-runtime:$roomVersion")
     annotationProcessor("androidx.room:room-compiler:$roomVersion")
 
     // To use Kotlin annotation processing tool (kapt)
-    kapt("androidx.room:room-compiler:$roomVersion")
+    //kapt("androidx.room:room-compiler:$roomVersion")
     // To use Kotlin Symbolic Processing (KSP)
     ksp("androidx.room:room-compiler:$roomVersion")
 
@@ -89,29 +86,29 @@ dependencies {
     implementation("androidx.room:room-ktx:$roomVersion")
 
     // optional - RxJava2 support for Room
-    implementation("androidx.room:room-rxjava2:$roomVersion")
+    //implementation("androidx.room:room-rxjava2:$roomVersion")
 
     // optional - RxJava3 support for Room
-    implementation("androidx.room:room-rxjava3:$roomVersion")
+    //implementation("androidx.room:room-rxjava3:$roomVersion")
 
     // optional - Guava support for Room, including Optional and ListenableFuture
-    implementation("androidx.room:room-guava:$roomVersion")
+    //implementation("androidx.room:room-guava:$roomVersion")
 
     // optional - Test helpers
     testImplementation("androidx.room:room-testing:$roomVersion")
 
     // optional - Paging 3 Integration
-    implementation("androidx.room:room-paging:2.4.0-alpha05")
+    //implementation("androidx.room:room-paging:2.5.0-alpha02")
 
     /**
      * End Room Dependencies
      */
 
     //Kotlin Co-routines
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2")
 
     //Kotlin reflection
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.5.31")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.21")
 
 
     testImplementation("junit:junit:4.+")

--- a/projects/android/secure/proguard-rules.pro
+++ b/projects/android/secure/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-allowaccessmodification

--- a/projects/android/secure/src/main/java/io/swath/microsoft/security/database/SecurityDatabase.kt
+++ b/projects/android/secure/src/main/java/io/swath/microsoft/security/database/SecurityDatabase.kt
@@ -6,7 +6,7 @@ import io.swath.microsoft.security.database.dao.*
 import io.swath.microsoft.security.database.entities.*
 
 //TODO: Exporting the schema and having a plan for versioning/migration
-@Database(entities = [Account::class, Application::class, Cloud::class, Feature::class, Organization::class, AccountFeature::class], version = 1, exportSchema = false)
+@Database(entities = [Account::class, Application::class, Cloud::class, Feature::class, Organization::class, AccountFeature::class], version = 1)
 abstract class SecurityDatabase : RoomDatabase() {
     abstract fun accountDao(): AccountDao
     abstract fun organizationDao(): OrganizationDao

--- a/projects/android/secure/src/main/java/io/swath/microsoft/security/database/entities/AccountFeature.kt
+++ b/projects/android/secure/src/main/java/io/swath/microsoft/security/database/entities/AccountFeature.kt
@@ -3,26 +3,25 @@ package io.swath.microsoft.security.database.entities
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.ForeignKey.NO_ACTION
 
 @Entity(tableName = "AccountFeatureEnabled", primaryKeys = ["AccountId", "FeatureId", "OrganizationId"], foreignKeys = [
     ForeignKey(
         entity = Account::class,
         parentColumns = ["Id"],
         childColumns = ["AccountId"],
-        onDelete = NO_ACTION
+        onDelete = ForeignKey.NO_ACTION
     ),
     ForeignKey(
         entity = Feature::class,
         parentColumns = ["Id"],
         childColumns = ["FeatureId"],
-        onDelete = NO_ACTION
+        onDelete = ForeignKey.NO_ACTION
     ),
     ForeignKey(
         entity = Organization::class,
         parentColumns = ["TenantId"],
         childColumns = ["OrganizationId"],
-        onDelete = NO_ACTION
+        onDelete = ForeignKey.NO_ACTION
     )
 ])
 data class AccountFeature(


### PR DESCRIPTION
Updated:

- Kotlin, Compose and Room library versions
- Fixed breaking changes introduced by those libraries
- NOTE: I didn't update to the latest Kotlin as it's not yet compatible with Jetpack compose.  See: https://developer.android.com/jetpack/androidx/releases/compose-kotlin
- I changed the target SDK to 32, which is required by the latest version of Jetpack Compose
- I commented out refrences to optional libraries for Room and compose
- I selected KSP over KAPT for room database code generation

NOTE: I didn't take the latest Intune SDK yet, but i've added a work item for this.