### PR TITLE
Added support for interaction required when making silent request; ex…

### DIFF
--- a/projects/react/router/src/App.tsx
+++ b/projects/react/router/src/App.tsx
@@ -1,5 +1,5 @@
 import NavBar from './nav/NavBar';
-import { Route, Routes} from "react-router-dom";
+import { Route, Routes, useNavigate} from "react-router-dom";
 import Consent from './consent/Consent';
 import Scopes from './scopes/Scopes';
 import Home from './home/Home';
@@ -8,24 +8,31 @@ import { AuthProvider } from './auth/AuthProvider';
 import SignIn from './auth/SignIn';
 import Layout from './layout/Layout';
 import Profile from './graph/Profile';
+import InteractionRequired from './auth/InteractionRequired';
+import { TenantAlias } from './auth/TenantAlias';
 
 function App() {
 
   const apis = [{endpoint: "https://graph.microsoft.com"}];
+  const navigate = useNavigate();
+  const clientId = 'b5c2e510-4a17-4feb-b219-e55aa5b74144'; //Lab App Id
+  const redirectUri = 'http://localhost:3000/auth/client-redirect'; //Lab App 
+  const tenantAlias: TenantAlias = "organizations";
 
   return (
     <>
-    <AuthProvider clientId={'c8263c9e-3bd0-4ee6-af0c-799099b8ec56'} redirectUri={'http://localhost:3000'} apis={apis}>
+    <AuthProvider clientId={clientId} redirectUri={redirectUri} navigate={navigate} tenantAlias={tenantAlias} apis={apis}>
     <NavBar></NavBar>
     <Layout>
     <Routes>
-      
+      <Route path='*' element={<Home />} />
       <Route path="/" element={<Home />} />
       <Route path="/signin" element={<SignIn />} />
       <Route path="/consent" element={<Consent />} />
       <Route element={<ReadyCheckRoute />}>
         <Route path="/scopes" element={<Scopes />} />
         <Route path="/profile" element={<Profile />} />
+        <Route path="/interactionrequired" element={<InteractionRequired/>}/>
       </Route>
       
     </Routes>

--- a/projects/react/router/src/auth/AuthContext.ts
+++ b/projects/react/router/src/auth/AuthContext.ts
@@ -1,4 +1,3 @@
-import { IPublicClientApplication } from "@azure/msal-browser";
 import * as React from "react";
 import { IApiClient } from "./ApiClient";
 

--- a/projects/react/router/src/auth/AuthProvider.tsx
+++ b/projects/react/router/src/auth/AuthProvider.tsx
@@ -2,13 +2,18 @@ import { PublicClientApplication } from "@azure/msal-browser";
 import { Configuration } from "@azure/msal-browser/dist/config/Configuration";
 import { MsalProvider } from "@azure/msal-react";
 import { PropsWithChildren } from "react";
+import { NavigateFunction } from "react-router";
 import { ApiClient } from "./ApiClient";
 import { API, AuthContext, IAuthContext } from "./AuthContext";
+import { TenantAlias } from "./TenantAlias";
 
 export type AuthProviderProps = PropsWithChildren<{
     clientId: string,
     redirectUri: string,
+    navigate: NavigateFunction,
+    tenantAlias?: TenantAlias,
     apis?: API[],
+    
     providerConfig?: any,
 
 }>;
@@ -21,7 +26,7 @@ export type AuthProviderProps = PropsWithChildren<{
  * @param providerConfig: optional: Additional provider configuration (reserved)
  * @returns 
  */
-export function AuthProvider({clientId, redirectUri, apis = [{endpoint: "https://graph.microsoft.com"}], providerConfig, children}: AuthProviderProps) : React.ReactElement {
+export function AuthProvider({clientId, redirectUri, navigate, tenantAlias="common", apis = [{endpoint: "https://graph.microsoft.com"}], providerConfig, children}: AuthProviderProps) : React.ReactElement {
 
     let msalConfig: Configuration;
 
@@ -31,7 +36,7 @@ export function AuthProvider({clientId, redirectUri, apis = [{endpoint: "https:/
         msalConfig = {
             auth: {
             clientId: clientId,
-            authority: "https://login.microsoftonline.com/consumers",
+            authority: "https://login.microsoftonline.com/".concat(tenantAlias),
             redirectUri: redirectUri
             },
             cache: {
@@ -43,7 +48,7 @@ export function AuthProvider({clientId, redirectUri, apis = [{endpoint: "https:/
 
     
     const msalInstance = new PublicClientApplication(msalConfig);
-    const apiClient = new ApiClient(msalInstance, apis);
+    const apiClient = new ApiClient(msalInstance, apis, navigate);
 
     const contextValue : IAuthContext = {
         apis : apis,

--- a/projects/react/router/src/auth/InteractionRequiredDetails.ts
+++ b/projects/react/router/src/auth/InteractionRequiredDetails.ts
@@ -1,0 +1,14 @@
+import { SilentRequest } from "@azure/msal-browser";
+
+/**
+ * Details of the silent request that failed to use in resolution via interaction by the end user
+ * 
+ * silentRequest: The request that failed
+ * subErrorCode: An error code returned by STS which indicates whether the error can be resolved and the level of difficulty for the end user
+ * challenge: Any challenge returned by the token endpoint relative to conditional access policy (expressed as a claims request)
+ */
+export type InteractionRequiredDetails = {
+    silentRequest: SilentRequest,
+    subErrorCode: any,
+    challenge: any
+}

--- a/projects/react/router/src/auth/SignIn.tsx
+++ b/projects/react/router/src/auth/SignIn.tsx
@@ -1,3 +1,4 @@
+import { OIDC_DEFAULT_SCOPES } from '@azure/msal-common';
 import { useMsal, useIsAuthenticated } from '@azure/msal-react';
 import { Navigate, useLocation } from 'react-router-dom';
 //import logoDark from '../assets/ms-symbollockup_signin_dark_short.svg';
@@ -10,7 +11,7 @@ function SignIn(){
     const {state} = useLocation();
 
     const loginRequest = {
-        scopes: ["User.Read"]
+        scopes: OIDC_DEFAULT_SCOPES.concat(["https://graph.microsoft.com//.default"])
     };
 
     const handleLogin = () => {

--- a/projects/react/router/src/auth/TenantAlias.ts
+++ b/projects/react/router/src/auth/TenantAlias.ts
@@ -1,0 +1,10 @@
+/**
+ *  Tenant Aliases
+ */
+export type TenantAlias =
+    /** @member: use when your app is configured to support all Microsoft Identity sign in audiences (work or school and personal accounts) */
+    "common" |
+    /** @member: use when your app is configured to support organization Microsoft Identity sign in audiences (work or school) */
+    "organizations" |
+    /** @member: use when your app is configured to support consumer Microsoft Identity sign in audiences (personal accounts) */
+    "consumers"


### PR DESCRIPTION
- added tenantAlias as an optional property of AuthProvider (defaults to common)
- updated to use lab app id / redirect uri
- added default route (matching all routes) - sends to root
- added NavigateFunction as a property of AuthProvider - Which then is supplied to the ApiClient
- define interactionRequiredDetails type to pass state from ApiClient to /interactionrequired route
- added interationrequired route and functional component
- NOTE: I've been adding type guards here and there and at some point I'll want to refactor them to somewhere more re-usable